### PR TITLE
Add filesystem=xdg-run/gvfs

### DIFF
--- a/org.gnome.TextEditor.json
+++ b/org.gnome.TextEditor.json
@@ -11,6 +11,7 @@
         "--socket=wayland",
         "--talk-name=org.freedesktop.FileManager1",
         "--filesystem=host",
+        "--filesystem=xdg-run/gvfs",
         "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs.*"
     ],


### PR DESCRIPTION
Without `filesystem=xdg-run/gvfs` I can only read files from a gvfs network mount but when trying to write to them I get the error "Operation not supported".
With `filesystem=xdg-run/gvfs` it works.

I'm on Fedora Linux 39.20240510.0 (Silverblue), in case it is relevant.