### PR TITLE
Improve cleanup commands

### DIFF
--- a/org.gnome.TextEditor.json
+++ b/org.gnome.TextEditor.json
@@ -17,6 +17,7 @@
     ],
     "cleanup": [
         "/include",
+        "/lib/cmake",
         "/lib/girepository-1.0",
         "/lib/pkgconfig",
         "/man",


### PR DESCRIPTION
Remove the development-related `/lib/cmake` folder.

See: https://github.com/flathub-infra/vorarbeiter/actions/runs/23264876983/job/67643023555#step:22:43